### PR TITLE
[protoc-gen-go-jsonpb] Allow unknown fields in JSON unmarshalling

### DIFF
--- a/protoc-gen-go-jsonpb/main.go
+++ b/protoc-gen-go-jsonpb/main.go
@@ -24,6 +24,8 @@ var (
 package {{.GoPkg}}
 
 import (
+    "strings"
+
     "github.com/golang/protobuf/jsonpb"
 )
 `))
@@ -38,7 +40,8 @@ func (msg *{{.GetName}}) MarshalJSON() ([]byte, error) {
 }
 
 func (msg *{{.GetName}}) UnmarshalJSON(src []byte) error {
-    return jsonpb.UnmarshalString(string(src), msg)
+    u := jsonpb.Unmarshaler{AllowUnknownFields: true}
+    return u.Unmarshal(strings.NewReader(string(src)), msg)
 }
 `))
 )


### PR DESCRIPTION
- By default, jsonpb raises an error if a JSON document to unmarshal
 contains fields that do not exist in a proto (or are deprecated
 using "reserved")
- This patch allows unknown fields in the JSON document when
 unmarshalling